### PR TITLE
Ilge/stab 167

### DIFF
--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -654,6 +654,22 @@ final class TDSChannel {
     }
 
     /**
+     * Close SSL Socket without overriding streams.
+     */
+    void closeSSLSocket() {
+        try {
+            if (logger.isLoggable(Level.FINER))
+                logger.finer(toString() + " Closing SSL socket");
+
+            sslSocket.close();
+        }
+        catch (IOException e) {
+            // Don't care if we can't close the SSL socket. We're done with it anyway.
+            logger.fine("Ignored error closing SSLSocket: " + e.getMessage());
+        }
+    }
+
+    /**
      * Disables SSL on this TDS channel.
      */
     void disableSSL() {
@@ -698,16 +714,7 @@ final class TDSChannel {
 
         // Now close the SSL socket. It will see that the proxy socket's streams
         // are closed and not try to do any further I/O over them.
-        try {
-            if (logger.isLoggable(Level.FINER))
-                logger.finer(toString() + " Closing SSL socket");
-
-            sslSocket.close();
-        }
-        catch (IOException e) {
-            // Don't care if we can't close the SSL socket. We're done with it anyway.
-            logger.fine("Ignored error closing SSLSocket: " + e.getMessage());
-        }
+        closeSSLSocket();
 
         // Do not close the proxy socket. Doing so would close our TCP socket
         // to which the proxy socket is bound. Instead, just null out the reference
@@ -2023,7 +2030,7 @@ final class TDSChannel {
 
     final void close() {
         if (null != sslSocket)
-            disableSSL();
+            closeSSLSocket();
 
         if (null != inputStream) {
             if (logger.isLoggable(Level.FINEST))

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -2029,8 +2029,17 @@ final class TDSChannel {
     }
 
     final void close() {
-        if (null != sslSocket)
+        if (null != sslSocket) {
             closeSSLSocket();
+        } else if (null != tcpSocket) {
+            // the connection is not using SSL, but closing tcp gracefully doesn't terminate correctly
+            // so we will abort connection for non-SSL here...
+            try {
+                tcpSocket.setSoLinger(true, 0);
+            } catch (java.net.SocketException e) {
+                logger.finest(this.toString() + ": Ignored error setting so linger...");
+            }
+        }
 
         if (null != inputStream) {
             if (logger.isLoggable(Level.FINEST))

--- a/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
+++ b/src/main/java/com/microsoft/sqlserver/jdbc/IOBuffer.java
@@ -2291,7 +2291,12 @@ final class SocketFinder {
             // inetAddrs is only used if useParallel is true or TNIR is true. Skip resolving address if that's not the case.
             if (useParallel || useTnir) {
                 // Ignore TNIR if host resolves to more than 64 IPs. Make sure we are using original timeout for this.
-                inetAddrs = InetAddress.getAllByName(hostName);
+                try {
+                    inetAddrs = InetAddress.getAllByName(hostName);
+                }
+                catch (java.net.UnknownHostException ex) {
+                    logger.finer("Failed to look up host");
+                }
 
                 if ((useTnir) && (inetAddrs.length > ipAddressLimit)) {
                     useTnir = false;
@@ -2636,8 +2641,8 @@ final class SocketFinder {
     private Socket getConnectedSocket(InetSocketAddress addr,
             int timeoutInMilliSeconds) throws IOException {
         assert timeoutInMilliSeconds != 0 : "timeout cannot be zero";
-        if (addr.isUnresolved())
-            throw new java.net.UnknownHostException();
+//        if (addr.isUnresolved())
+//            throw new java.net.UnknownHostException();
         selectedSocket = new Socket();
         selectedSocket.connect(addr, timeoutInMilliSeconds);
         return selectedSocket;


### PR DESCRIPTION
Latest stable mssql jdbc driver does not close TCP sockets properly, which is a problem exacerbated when used over a proxy. 
A series of patches are necessary to close connections properly (for SSL, this is simply done by not using mock I/O streams while closing the SSL socket, for non-SSL, the socket hangs on read while closing the ssl protocol, so we force-abort the TCP connection to force exchange of FINs)
Additional fix to not throw exception on hostname lookup failures in jdbc driver: for SSH tunneled connections, the hostname is in a special format meant to be resolved by SOCKS, therefore shouldn't be enforced resolve to a valid name)